### PR TITLE
Ensuring that the program is python3 compatible.

### DIFF
--- a/hiragana.py
+++ b/hiragana.py
@@ -141,7 +141,11 @@ def trial(choice):
     :type choice: tuple
     :return bool
     """
-    hiragana = raw_input("Please enter " + choice[0] + ": ")
+    if sys.version_info[0] > 2:
+        get_input = input
+    else:
+        get_input = raw_input
+    hiragana = get_input("Please enter " + choice[0] + ": ")
     return hiragana == choice[0]
 
 


### PR DESCRIPTION
Hi! 

I was trying to run your program to check it out and encountered an issue since I was trying to run it with python3:

Traceback (most recent call last):
  File "learn_hiragana\hiragana.py", line 195, in <module>
    main()
  File "learn_hiragana\hiragana.py", line 179, in main
    if trial(choice):
  File "learn_hiragana\hiragana.py", line 145, in trial
    get_input = raw_input
NameError: name 'raw_input' is not defined

 I have therefore added a small fix that checks for the python version running and then sets the appropriate input function to be used (raw_input() for python2 and input() for python3). 

Keep up the great work!